### PR TITLE
Fix high DPI scaling issues in Windows (and Linux?)

### DIFF
--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -43,8 +43,6 @@ ext.jvmArgs = [
     "com.apple.macos.use-file-dialog-packages": "true",
     "com.apple.macos.useScreenMenuBar": "true",
     "com.apple.smallTabs": "true",
-    // See, https://forum.jogamp.org/JOGL-broken-with-JRE-8-and-Windows-window-scaling-tp4039122p4039665.html
-    "sun.java2d.uiScale": "1.0", // Avoids bug with high DPI and scaling != 100% on Windows with Java > 8
     "java.util.logging.config.file": "logging.properties" ]
 ext.vzomeArgs = [  // a list, not a map
     '-entitlement.model.edit', 'true', '-entitlement.lesson.edit', 'true', '-entitlement.all.tools', 'true',

--- a/desktop/src/main/java/org/vorthmann/j3d/Platform.java
+++ b/desktop/src/main/java/org/vorthmann/j3d/Platform.java
@@ -27,10 +27,17 @@ public class Platform
         try {
             String os = System .getProperty( "os.name" );
             logger .log(Level.FINE, "os.name: {0}", os);
-            if ( os != null && os .startsWith( "Mac" ) )
-                isMac = true;
-            else if ( os != null && os .startsWith( "Win" ) )
-                isWindows = true;
+			if (os != null && os.startsWith("Mac")) {
+				isMac = true;
+			} else {
+				// "vzome.glcanvas.rescaling" is used 
+				// in JoglFactory.createRenderingViewer()
+				// and JoglRenderingViewer.pickRay()
+				System.setProperty("vzome.glcanvas.rescaling", "true");
+				if (os != null && os.startsWith("Win")) {
+					isWindows = true;
+				}
+			}
             os = System .getProperty( "java.specification.version" );
             logger .log(Level.FINE, "java.specification.version: {0}", os);
         } catch ( SecurityException e ) {

--- a/desktop/src/main/java/org/vorthmann/zome/render/jogl/JoglFactory.java
+++ b/desktop/src/main/java/org/vorthmann/zome/render/jogl/JoglFactory.java
@@ -1,6 +1,7 @@
 
 package org.vorthmann.zome.render.jogl;
 
+import java.awt.GraphicsConfiguration;
 import java.util.List;
 
 import org.vorthmann.j3d.J3dComponentFactory;
@@ -67,8 +68,46 @@ public class JoglFactory implements J3dComponentFactory
         // GLCanvas for the trackball view on the Mac gets "left behind" when resizing the window,
         //  a defect in JOGL.  The remedy is to use the lightweight GLJPanel for that situation,
         //  which behaves correctly, though it delivers a much lower frame rate than GLCanvas.
-        
-        GLAutoDrawable glcanvas = lightweight? new GLJPanel( glcapabilities, chooser ) : new GLCanvas( glcapabilities, chooser, null );
+        @SuppressWarnings("serial")
+		GLAutoDrawable glcanvas = lightweight
+        		? new GLJPanel( glcapabilities, chooser ) 
+        		: !"true".equals(System.getProperty("vzome.glcanvas.rescaling"))
+        			? new GLCanvas( glcapabilities, chooser, null ) // No override needed
+        			: new GLCanvas( glcapabilities, chooser, null ) {
+                	// Fix for High DPI scaling bug on Windows and Linux
+                	// Bug described at https://jogamp.org/bugzilla/show_bug.cgi?id=1358#c23
+            		// and https://forum.jogamp.org/JOGL-broken-with-JRE-8-and-Windows-window-scaling-tp4039122p4039665.html
+        			// 
+                	// Solution at https://jogamp.org/bugzilla/show_bug.cgi?id=1374#c5
+                	//
+                	// Sample code at the end of https://gist.github.com/maheshkurmi/e984430d33236b6bfb7c3de0f8a1a0e5
+                	// https://github.com/LWJGLX/lwjgl3-awt/issues/53#issuecomment-946005871
+                	// shows how to get the correct scaling factor at runtime even when switching monitors with different scaling factors.
+                	//
+                	// JoglRenderingViewer.pickRay() depends on these overridden methods.
+                	// They also make the model viewer display correctly on Windows High DPI monitors
+                	// with scaling set to anything other than 100%.
+                	//
+                	// This overload of getPreferredSize seems pointless but it's shown as part of the solution.
+                	// I'm just going to comment it out and see if it has any down side.
+//            		@Override
+//            		public Dimension getPreferredSize() {
+//            			Dimension d=super.getPreferredSize();
+//            			return new Dimension(d.width,d.height);
+//            		}
+            		@Override
+            		public int getWidth() {
+            			GraphicsConfiguration gc = getGraphicsConfiguration();
+            			double scale = gc == null ? 1.0 : gc.getDefaultTransform().getScaleX();
+            			return (int)(super.getWidth() * scale);
+            		}
+            		@Override
+            		public int getHeight() {
+            			GraphicsConfiguration gc = getGraphicsConfiguration();
+            			double scale = gc == null ? 1.0 : gc.getDefaultTransform().getScaleY();
+            			return (int)(super.getHeight() * scale);
+            		}
+            	};
         
         return new JoglRenderingViewer( scene, glcanvas );
     }

--- a/desktop/src/main/java/org/vorthmann/zome/render/jogl/JoglRenderingViewer.java
+++ b/desktop/src/main/java/org/vorthmann/zome/render/jogl/JoglRenderingViewer.java
@@ -3,6 +3,7 @@ package org.vorthmann.zome.render.jogl;
 
 import java.awt.Component;
 import java.awt.event.MouseEvent;
+import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 
 import javax.vecmath.Matrix4f;
@@ -50,6 +51,8 @@ public class JoglRenderingViewer implements RenderingViewer, GLEventListener
 {
     private final Scene scene;
     private final Component canvas;
+    // cache the value of fixGLCanvasRescaling one time here to improve performance in pickRay() 
+    private final boolean fixGLCanvasRescaling = "true".equals(System.getProperty("vzome.glcanvas.rescaling"));
     
     private JoglOpenGlShim glShim;
     private Renderer outlines = null;
@@ -235,6 +238,14 @@ public class JoglRenderingViewer implements RenderingViewer, GLEventListener
         int mouseX = e .getX();
         int mouseY = e .getY();
         
+        // This work-around for scaling issues on Windows and Linux assumes that the canvas 
+        // is a GLCanvas with getWidth() and getHeight() overridden 
+        // to incorporate the scale factor as I've done in JoglFactory.createRenderingViewer()  
+        if(fixGLCanvasRescaling) {
+        	AffineTransform t = canvas.getGraphicsConfiguration().getDefaultTransform(); 
+            mouseX *= t.getScaleX();
+            mouseY *= t.getScaleY();
+        }
         // I wasted a lot of time here looking at the Java3d implementation, which had a bug.
         //  Furthermore, it was based on the Java3d notion of "image plate" coordinates, which
         //  are hard to understand in terms of OpenGL, at least from the documentation I could


### PR DESCRIPTION
* Remove JVM arg sun.java2d.uiScale=1.0.
* Set system property "vzome.glcanvas.rescaling" based on OS at runtime.
* Override GLCanvas if needed, as described at https://jogamp.org/bugzilla/show_bug.cgi?id=1374#c5
* Rescale mouse position in pickRay() if needed