### PR TITLE
Add monotonicity test case for JavaBigRational

### DIFF
--- a/online/test/bigRational.test.mjs
+++ b/online/test/bigRational.test.mjs
@@ -413,6 +413,29 @@ describe( 'JavaBigRational', () => {
     });
   });
 
+  // ── monotonic transition (to big representation) ───────────────────────────
+
+  describe( 'monotonicity', () => {
+    // Verifies there is a single transition threshold for BigInt representation.
+    it( 'big-ness is monotonic for values near MAX_SAFE_INTEGER', () => {
+      const SAFE = BigInt(Number.MAX_SAFE_INTEGER)
+      const span = 5 // how far to test above and below the transition threshold
+      let transitions = 0
+      for ( let i = -span; i <= span; i++ ) {
+        const S = SAFE + BigInt(i)
+        // console.log(S) // displays BEFORE test results
+        const curr = rat(S     , 1n)
+        const next = rat(S + 1n, 1n)
+        if ( curr.big != next.big ) {
+          transitions++
+          // console.log(curr) // displays BEFORE test results
+          // console.log(next) // displays BEFORE test results
+        }
+      }
+      assert.equal(transitions, 1 );
+    });
+  });
+
   // ── bugfix1 from Java tests ────────────────────────────────
 
   describe( 'bugfix1', () => {


### PR DESCRIPTION
The test didn't chase out any issues. It was more of an exercise for me. I think the implementation looks solid with or without this test case included.